### PR TITLE
When creating a pull request - reset the feature branch first

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Branch name to submit pull request to'
     required: false
     default: ''
+  PULL_REQUEST_LABEL:
+    description: 'Label to apply to any created pull request'
+    required: false
+    default: ''
   GIT_EMAIL:
     description: 'Email to use for Git'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,11 +47,13 @@ echo "Git initialized"
 
 echo " "
 
-PUSH_ARGS=""
 
 # loop through all the repos
 for repository in "${REPOSITORIES[@]}"; do
     echo "::group::$repository"
+
+    # extra arguments to use when pushing changes
+    PUSH_ARGS=""
 
     # determine repo name
     REPO_INFO=($(echo $repository | tr "@" "\n"))


### PR DESCRIPTION
When doing filesync via a pull request, I can do the following:

First, use the following

```
      - name: File Sync
        uses: github-action-file-sync
        with:
          REPOSITORIES: |
            test-repo@repo-config-sync
          FILES: |
            sync_file1=sync_file1
            sync_file2=sync_file2
          PULL_REQUEST_BRANCH_NAME: master
          TOKEN: ${{ secrets.REPO_CONFIG_SYNC_TOKEN }}
```

This opens a pull request against `test-repo`, using branch `repo-config-sync`. However, I haven't merged this PR yet, and I change the source to:

```
      - name: File Sync
        uses: github-action-file-sync
        with:
          REPOSITORIES: |
            test-repo@repo-config-sync
          FILES: |
            sync_file2=sync_file2
          PULL_REQUEST_BRANCH_NAME: master
          TOKEN: ${{ secrets.REPO_CONFIG_SYNC_TOKEN }}
```

The only difference is that `sync_file1` isn't part of the sync argument anymore. Given that the original change was never merged, it seems to me that the more accurate sync to do is to have the open PR always exactly reflect the difference between the source and managed repository - but right now, `sync_file1` still exists on the `test-repo@repo-config-sync` branch.

This PR performs a hard-reset and force-push of the `PULL_REQUEST_BRANCH_NAME` (only if it is different than the target branch) - so that the open PR always reflects the current state of the source repository. In this case, the PR would end up with only `sync_file2` in it - `sync_file1` would be removed from the PR.