### PR TITLE
Add documentation about workflow scope requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
 | PULL_REQUEST_BRANCH_NAME | false | Branch name of branch to do pull request into. Default is no pull request opened |
 | GIT_EMAIL | false | Git email to use |
 | GIT_USERNAME | false | Git username to use |
-| TOKEN | true | Personal Access Token with Repo scope |
+| TOKEN | true | Personal Access Token with repo scope, and workflow scope if managing Actions-related files |
 
 ## Examples
 ### REPOSITORIES parameter


### PR DESCRIPTION
See "workflow" permission under https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps.

On pushing changes, the user gets the log:
```
! [remote rejected] master -> master (refusing to allow a Personal Access Token to create or update workflow `.github/workflows/something.yaml` without `workflow` scope)
```

(separately, it probably shouldn't fail silently and report a successful status)